### PR TITLE
Revert "update to latest version of league/flysystem-azure-blob-storage"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     "require": {
         "silverstripe/framework": "^4.8",
         "silverstripe/vendor-plugin": "^1.0",
-        "league/flysystem-azure-blob-storage": "^3.3.0",
-        "league/flysystem-cached-adapter": "^1.1.0"
+        "league/flysystem-azure-blob-storage": "^1.0",
+        "league/flysystem-cached-adapter": "^1.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This reverts commit 8a942a1241274a30ac0cffb3e2b3b4fc1d67a8bd.

These version constraints don't work with silverstripe/framework 4